### PR TITLE
Use semver 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node-version-resolver": "^0.2.7",
     "pygmentize-bundled": "~2.1.0",
     "request": "^2.40.0",
-    "semver": "^3.0.1"
+    "semver": "^4.0.0"
   },
   "engines": {
     "node": "0.10.28"


### PR DESCRIPTION
This updated version of node-semver brings it more in line with the semver standard. Lots of gory details on [this blog post about npm2](http://blog.npmjs.org/post/98131109725/npm-2-0-0) by @othiym23.

Since node itself has been pretty much stagnating in 0.10.x land for so long, and Heroku has advised users to use the `0.10.x`-style range, this change will like have zero effect on existing users, but it's good to keep it up to date with "reality" for those users who are inclined to use carets and whatnot in their `engines` ranges.
