### PR TITLE
simpler filter, more tests for npm source

### DIFF
--- a/lib/sources/npm.js
+++ b/lib/sources/npm.js
@@ -39,10 +39,6 @@ NpmSource.prototype._parse = function(info) {
   var latestStable = info['dist-tags'].latest;
 
   this.all = versions.filter(semver.valid).sort(semver.compare);
-  this.stable = this.all.filter(lteStable);
+  this.stable = this.all.filter(semver.gte.bind(semver, latestStable));
   this.updated = new Date();
-
-  function lteStable(version) {
-    return semver.lte(version, latestStable);
-  }
 };

--- a/test/npm/source.test.coffee
+++ b/test/npm/source.test.coffee
@@ -7,7 +7,7 @@ fs = require "fs"
 Source = require "../../lib/sources/npm"
 json = require "../fixtures/npm.json"
 
-describe "Node Source", ->
+describe "Npm Source", ->
 
   describe "default properties", ->
 
@@ -32,11 +32,15 @@ describe "Node Source", ->
     it "has an array of all versions", ->
       assert.equal typeof(this.s.all), "object"
       assert.equal this.s.all.length, 99
+
+    it "shows version 2.1.12 as the latest unstable", ->
       assert.equal this.s.all[98], '2.1.12'
 
     it "has an array of stable versions", ->
       assert.equal typeof(this.s.stable), "object"
       assert.equal this.s.stable.length, 98
+
+    it "shows version 2.1.11 as the latest stable", ->
       assert.equal this.s.stable[97], '2.1.11'
 
     it "has been updated", ->


### PR DESCRIPTION
- Add tests to explicitly check npm stable vs unstable versions.
- Remove extraneous filter
