### PR TITLE
Mark all io.js semver-stable versions as stable

### DIFF
--- a/lib/sources/iojs.js
+++ b/lib/sources/iojs.js
@@ -40,10 +40,10 @@ IoJsSource.prototype._parse = function(body) {
   var versions = _.unique(body.match(SEMVER));
 
   this.all = versions.sort(semver.compare);
-  this.stable = versions.filter(isEven);
+  this.stable = versions.filter(isStable);
   this.updated = new Date();
 
-  function isEven(version) {
-    return semver(version).minor % 2 === 0;
+  function isStable(version) {
+    return semver.satisfies(version, '>=0.0.0');
   }
 };

--- a/test/iojs/integration.test.coffee
+++ b/test/iojs/integration.test.coffee
@@ -51,7 +51,7 @@ describe "IoJs Routes", ->
         .end (err, res) ->
           return done(err) if err
           assert semver.valid(res.text)
-          assert.equal(semver.parse(res.text).minor % 2, 0)
+          assert semver.satisfies(res.text, '>=0.0.0')
           done()
 
     it "works with a failing endpoint", (done) ->
@@ -62,7 +62,7 @@ describe "IoJs Routes", ->
         .end (err, res) ->
           return done(err) if err
           assert semver.valid(res.text)
-          assert.equal(semver.parse(res.text).minor % 2, 0)
+          assert semver.satisfies(res.text, '>=0.0.0')
           done()
 
   describe "GET /iojs/unstable", ->


### PR DESCRIPTION
io.js doesn't follow the Node.js convention of "stable = minor is even"

Fix #34