### PR TITLE
Updates Node releases from both release and rc download directories

### DIFF
--- a/lib/sources/node.js
+++ b/lib/sources/node.js
@@ -13,7 +13,8 @@ module.exports = NodeSource;
 function NodeSource(options) {
   _.extend(this, {
     name: 'node',
-    url: 'http://nodejs.org/dist/',
+    releaseUrl: 'https://nodejs.org/download/release/',
+    candidateUrl: 'https://nodejs.org/download/rc/',
     all: [],
     stable: [],
     updated: undefined
@@ -21,10 +22,12 @@ function NodeSource(options) {
 }
 
 NodeSource.prototype.update = function(done) {
+  var responseText = '';
+
   done = done || NOOP;
 
   agent
-    .get(this.url)
+    .get(this.releaseUrl)
     .timeout(TIMEOUT)
     .end(parseResponse.bind(this));
 
@@ -33,12 +36,30 @@ NodeSource.prototype.update = function(done) {
     if (!res.text) return done(new Error('No response'), false);
     if (res.status !== 200) return done(new Error('Bad response'), false);
 
-    this._parse(res.text)
-    done(undefined, true);
+      responseText += res.text;
+
+      agent
+        .get(this.candidateUrl)
+        .timeout(TIMEOUT)
+        .end(parseResponse.bind(this));
+
+      function parseResponse(err, res) {
+        if (err) return done(err, false);
+        if (!res.text) return done(new Error('No response'), false);
+        if (res.status !== 200) return done(new Error('Bad response'), false);
+
+        responseText += res.text;
+        this._parse(responseText)
+        done(undefined, true);
+
+      }
+
   }
+
 };
 
 NodeSource.prototype._parse = function(body) {
+
   var versions = _.unique(body.match(SEMVER));
 
   this.all = versions.sort(semver.compare);

--- a/lib/sources/node.js
+++ b/lib/sources/node.js
@@ -36,23 +36,23 @@ NodeSource.prototype.update = function(done) {
     if (!res.text) return done(new Error('No response'), false);
     if (res.status !== 200) return done(new Error('Bad response'), false);
 
+    responseText += res.text;
+
+    agent
+      .get(this.candidateUrl)
+      .timeout(TIMEOUT)
+      .end(parseResponse.bind(this));
+
+    function parseResponse(err, res) {
+      if (err) return done(err, false);
+      if (!res.text) return done(new Error('No response'), false);
+      if (res.status !== 200) return done(new Error('Bad response'), false);
+
       responseText += res.text;
+      this._parse(responseText)
+      done(undefined, true);
 
-      agent
-        .get(this.candidateUrl)
-        .timeout(TIMEOUT)
-        .end(parseResponse.bind(this));
-
-      function parseResponse(err, res) {
-        if (err) return done(err, false);
-        if (!res.text) return done(new Error('No response'), false);
-        if (res.status !== 200) return done(new Error('Bad response'), false);
-
-        responseText += res.text;
-        this._parse(responseText)
-        done(undefined, true);
-
-      }
+    }
 
   }
 

--- a/test/node/integration.test.coffee
+++ b/test/node/integration.test.coffee
@@ -34,7 +34,15 @@ describe "Node Routes", ->
 
     it "redirects the failing app to a false endpoint", (done) ->
       this.timeout(20000)
-      failingApp.resolvers.node.source.url = 'http://nodejs.org/fail/';
+      failingApp.resolvers.node.source.releaseUrl = 'http://nodejs.org/fail/';
+      failingApp.resolvers.node.update (err, updated) ->
+        assert(err)
+        assert(!updated)
+        done()
+
+    it "redirects the failing app to a false endpoint", (done) ->
+      this.timeout(20000)
+      failingApp.resolvers.node.source.candidateUrl = 'http://nodejs.org/fail/';
       failingApp.resolvers.node.update (err, updated) ->
         assert(err)
         assert(!updated)
@@ -77,7 +85,6 @@ describe "Node Routes", ->
         .end (err, res) ->
           return done(err) if err
           assert semver.valid(res.text)
-          assert.equal(semver.parse(res.text).minor, 12)
           done()
 
     it "works with a failing endpoint", (done) ->
@@ -88,7 +95,6 @@ describe "Node Routes", ->
         .end (err, res) ->
           return done(err) if err
           assert semver.valid(res.text)
-          assert.equal(semver.parse(res.text).minor, 12)
           done()
 
   describe "GET /node/resolve/0.8.x", ->

--- a/test/node/source.test.coffee
+++ b/test/node/source.test.coffee
@@ -20,8 +20,11 @@ describe "Node Source", ->
     it "default to empty stable array", ->
       assert.equal this.s.stable.length, 0
 
-    it "defaults to the 'http://nodejs.org/dist/' url", ->
-      assert.equal this.s.url, 'http://nodejs.org/dist/'
+    it "defaults releases to the 'https://nodejs.org/download/release/' url", ->
+      assert.equal this.s.releaseUrl, 'https://nodejs.org/download/release/'
+
+    it "defaults release candidates to the 'https://nodejs.org/download/rc/' url", ->
+      assert.equal this.s.candidateUrl, 'https://nodejs.org/download/rc/'
 
     it "has never been updated", ->
       assert.ok !this.s.updated


### PR DESCRIPTION
Builds on the work by Michał Gołębiowski to make two requests to both https://nodejs.org/download/release/ and https://nodejs.org/download/rc/ to add release candidates to the list of the Node versions and subsequently (as of 7th Sep 2015) show 4.0.0-rc.2 at /node/unstable - was previously incorrectly showing 0.12.7

I'm more than happy for any feedback on this and any changes that need to be made.